### PR TITLE
feat: add rule for config vue [keabab-case in templates]

### DIFF
--- a/packages/eslint-config-vue3-convidera/index.js
+++ b/packages/eslint-config-vue3-convidera/index.js
@@ -15,5 +15,13 @@ module.exports = {
   rules: {
     'vue/script-setup-uses-vars': 'error',
     'vue/multi-word-component-names': 0,
+    'vue/component-name-in-template-casing': [
+      'error',
+      'kebab-case',
+      {
+        registeredComponentsOnly: false,
+        ignores: [],
+      },
+    ],
   },
 };


### PR DESCRIPTION
Add rule which would force devs to write component names in template using kebab-case style